### PR TITLE
updated memory to use 320M instead of 256M

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,6 @@
 ---
 applications:
 - name: cf-hello
-  memory: 256M
+  memory: 320M
   instances: 1
   host: cf-hello-${random-word}


### PR DESCRIPTION
I experienced an out of memory exception upon pushing the app to PWS:

`2016-11-17T21:15:02.78+0100 [API/1]      OUT App instance exited with guid 02dfb979-32a6-4c04-b781-3580fd1a29d5 payload: {"instance"=>"", "index"=>0, "reason"=>"CRASHED", "exit_description"=>"2 error(s) occurred:\n\n* 2 error(s) occurred:\n\n* Exited with status 137 (out of memory)\n* cancelled\n* cancelled", "crash_count"=>4, "crash_timestamp"=>1479413702703356018, "version"=>"9f8aae9d-5d02-438e-92b9-2e6e164feae1"}`

With a bit more memory (320MB) it works fine. 